### PR TITLE
fix: decouple email notification from app deployment status update

### DIFF
--- a/src/controllers/customhost.ts
+++ b/src/controllers/customhost.ts
@@ -200,31 +200,20 @@ const patchCustomHostByIdHandler = factory.createHandlers(
         }
       }
 
-      // if the updatedCustomHost contains both androidShareLink and iosShareLink
-      // then find the app_form and update the status of the app_form to DEPLOYED if it is not already DEPLOYED
+      // When any of the android or ios share links are updated,
+      //  - Then we need to send email to the creator based on the action.
+      //  - Also if both link exists, then update the app form to "DEPLOYED" (ie, if not already in DEPLOYED state).
       if (
         updatedCustomHost &&
-        updatedCustomHost.androidShareLink &&
-        updatedCustomHost.iosShareLink
+        (updatedCustomHost.androidShareLink || updatedCustomHost.iosShareLink)
       ) {
         const appForm = await Mongo.app_forms.findOne({
           host: new ObjectId(id),
           parentForm: { $exists: false },
         });
+
+        // if the app form is not deployed, then enqueue the message to deploy the app
         if (appForm && appForm.status !== AppFormStatus.DEPLOYED) {
-          await Mongo.app_forms.findOneAndUpdate(
-            {
-              host: new ObjectId(id),
-              parentForm: { $exists: false },
-            },
-            {
-              $set: {
-                showAppsLiveBannerToCreator: true,
-                status: AppFormStatus.DEPLOYED,
-                updatedAt: new Date(),
-              },
-            },
-          );
           await awsService.enqueueMessage(
             "appzap.app.deployed",
             {
@@ -232,6 +221,26 @@ const patchCustomHostByIdHandler = factory.createHandlers(
             },
             {},
           );
+
+          // if the android and ios share links are present, then update the app form to deployed
+          if (
+            updatedCustomHost.androidShareLink &&
+            updatedCustomHost.iosShareLink
+          ) {
+            await Mongo.app_forms.findOneAndUpdate(
+              {
+                host: new ObjectId(id),
+                parentForm: { $exists: false },
+              },
+              {
+                $set: {
+                  showAppsLiveBannerToCreator: true,
+                  status: AppFormStatus.DEPLOYED,
+                  updatedAt: new Date(),
+                },
+              },
+            );
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

- **Trigger email notifications on partial share link updates**: Previously, the "app deployed" email was only sent when *both* `androidShareLink` and `iosShareLink` were present. This meant creators wouldn't receive a notification if only one platform's link was updated first. The condition has been changed to trigger the SQS message when *either* link is updated.

- **Retain strict condition for marking app form as DEPLOYED**: The actual `app_forms` status update to `DEPLOYED` (and showing the live banner to the creator) still requires *both* `androidShareLink` and `iosShareLink` to be present, ensuring the deployment state is only set when both platforms are live.

## Changes

- `src/controllers/customhost.ts`: Separated the logic for enqueuing the `appzap.app.deployed` SQS message from the logic that updates the `app_forms` document to `DEPLOYED` status. The enqueue now fires when either share link is updated, while the DB status update only happens when both links exist.

Note: the testing will be done by [@rhnmht30](https://github.com/rhnmht30)