### PR TITLE
feat(TMG-791): auto-complete deployment request once store version goes live

### DIFF
--- a/src/schedules/index.ts
+++ b/src/schedules/index.ts
@@ -111,6 +111,29 @@ Mongo.connect().then(() => {
             },
           );
           count++;
+
+          const deployedVersion =
+            metadata.iosDeploymentDetails?.lastDeploymentDetails?.versionName;
+          const isLive =
+            appVersionState === "READY_FOR_SALE" ||
+            appVersionState === "READY_FOR_DISTRIBUTION";
+
+          if (deployedVersion && appVersion === deployedVersion && isLive) {
+            const flipResult = await Mongo.deployment_requests.updateOne(
+              { host: metadata.host, "ios.status": "processing" },
+              {
+                $set: {
+                  "ios.status": "success",
+                  updatedAt: new Date(),
+                },
+              },
+            );
+            if (flipResult.modifiedCount > 0) {
+              console.log(
+                `Marked ios deployment request as success for host ${metadata.host}`,
+              );
+            }
+          }
         }
       } catch (error) {
         console.log(error);
@@ -346,7 +369,9 @@ Mongo.connect().then(() => {
       return new Promise((resolve) => setTimeout(resolve, delay));
     };
 
-    // Find all metadata with androidDeploymentDetails.bundleId that don't have playStore.versionName yet
+    // Find metadata with an android bundleId where the Play Store version is
+    // either unknown or out-of-date relative to the last AppZap-deployed version
+    // (so we re-scrape after a redeployment until the store catches up).
     const allMetadatas = await Mongo.metadata
       .find({
         $and: [
@@ -370,6 +395,14 @@ Mongo.connect().then(() => {
               {
                 "androidDeploymentDetails.playStore.versionName": {
                   $eq: "",
+                },
+              },
+              {
+                $expr: {
+                  $ne: [
+                    "$androidDeploymentDetails.lastDeploymentDetails.versionName",
+                    "$androidDeploymentDetails.playStore.versionName",
+                  ],
                 },
               },
             ],
@@ -537,6 +570,27 @@ Mongo.connect().then(() => {
                 },
               );
               count++;
+
+              const deployedVersion =
+                metadata.androidDeploymentDetails?.lastDeploymentDetails
+                  ?.versionName;
+
+              if (deployedVersion && version === deployedVersion) {
+                const flipResult = await Mongo.deployment_requests.updateOne(
+                  { host: metadata.host, "android.status": "processing" },
+                  {
+                    $set: {
+                      "android.status": "success",
+                      updatedAt: new Date(),
+                    },
+                  },
+                );
+                if (flipResult.modifiedCount > 0) {
+                  console.log(
+                    `Marked android deployment request as success for host ${metadata.host}`,
+                  );
+                }
+              }
             } else {
               console.log(`❌ ${bundleId}: Version not found`);
             }


### PR DESCRIPTION
## Summary
- iOS and Android store-version polling crons now flip the matching `deployment_requests.<platform>.status` from `processing` to `success` once the store-distributed version matches `lastDeploymentDetails.versionName` (iOS additionally gated on Apple's `appVersionState` being `READY_FOR_SALE` / `READY_FOR_DISTRIBUTION`).
- The flip's match clause is filtered on `"<platform>.status": "processing"`, so requests in `pending` / `success` / `failed` are never touched.
- Widened the Android cron's metadata query to also pick up hosts where `playStore.versionName` is stale relative to `lastDeploymentDetails.versionName`, so the scrape actually re-runs after a redeployment (previously it only ran for hosts that had never been scraped).

Jira: https://tagmango.atlassian.net/browse/TMG-791

## Test plan
- [x] Verified end-to-end against prod for host `657abf4a71c7ef8f12cb7e24`: with an iOS deployment request in `processing` and metadata matching the live App Store version, running the iOS cron logic flipped the request to `success` (`matched=1 modified=1`).
- [ ] After deploy, confirm next scheduled iOS cron run leaves non-`processing` requests untouched.
- [ ] After deploy, confirm Android cron re-scrapes hosts whose `lastDeploymentDetails.versionName` differs from `playStore.versionName` and flips the matching deployment request once the Play Store catches up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)