### PR TITLE
feat: sync appreleaseversions on PATCH /wl/release

### DIFF
--- a/src/controllers/release.ts
+++ b/src/controllers/release.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 
 import { zValidator } from "@hono/zod-validator";
 
+import Mongo from "../database";
 import { Response } from "../utils/statuscode";
 import { updateReleaseDetailsSchema } from "../validations/release";
 
@@ -43,10 +44,27 @@ const updateReleaseDetails = factory.createHandlers(
       const rawReleaseDetails = await readFile(releaseFilePath, "utf-8");
 
       const parsedReleaseDetails = JSON.parse(rawReleaseDetails);
-      await writeFile(
-        releaseFilePath,
-        JSON.stringify({ ...parsedReleaseDetails, ...body }),
+      const mergedReleaseDetails = { ...parsedReleaseDetails, ...body };
+
+      await writeFile(releaseFilePath, JSON.stringify(mergedReleaseDetails));
+
+      // Keep the singleton appreleaseversions document in sync with the file
+      // so core-api's latestAvailableVersionName reflects the new release.
+      const now = new Date();
+      await Mongo.app_release_versions.updateOne(
+        {},
+        {
+          $set: {
+            versionName: mergedReleaseDetails.versionName,
+            buildNumber: mergedReleaseDetails.buildNumber,
+            releaseNotes: mergedReleaseDetails.releaseNotes,
+            updatedAt: now,
+          },
+          $setOnInsert: { createdAt: now },
+        },
+        { upsert: true },
       );
+
       return c.json(
         {
           message: "Release details updated successfully",
@@ -54,6 +72,7 @@ const updateReleaseDetails = factory.createHandlers(
         Response.OK,
       );
     } catch (error) {
+      console.error("Error updating release details:", error);
       return c.json(
         { message: "Internal Server Error" },
         Response.INTERNAL_SERVER_ERROR,

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -6,6 +6,7 @@ import {
   Collections,
   IAdminUser,
   IAppForm,
+  IAppReleaseVersions,
   IChapter,
   ICourse,
   ICustomHost,
@@ -45,6 +46,7 @@ abstract class Mongo {
   public static developer_accounts_ios: Collection<IDeveloperAccountIos>;
   public static app_forms: Collection<IAppForm>;
   public static deployment_requests: Collection<IDeploymentRequest>;
+  public static app_release_versions: Collection<IAppReleaseVersions>;
 
   public static async connect(): Promise<void> {
     try {
@@ -88,6 +90,9 @@ abstract class Mongo {
       this.app_forms = this.db.collection<IAppForm>(Collections.APP_FORM);
       this.deployment_requests = this.db.collection<IDeploymentRequest>(
         Collections.APP_DEPLOYMENT_REQUESTS,
+      );
+      this.app_release_versions = this.db.collection<IAppReleaseVersions>(
+        Collections.APP_RELEASE_VERSIONS,
       );
     } catch (error) {
       console.log(`Error connecting to database: ${error}`);

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -17,6 +17,7 @@ export const Collections = {
   DEVELOPER_ACCOUNT_IOS: "iosdeveloperaccounts",
   APP_FORM: "appforms",
   APP_DEPLOYMENT_REQUESTS: "appdeploymentrequests",
+  APP_RELEASE_VERSIONS: "appreleaseversions",
 } as const;
 
 export const Platform = {
@@ -681,6 +682,15 @@ export interface IDeploymentRequest {
   host: ObjectId;
   android?: IPlatformDeploymentRequest;
   ios?: IPlatformDeploymentRequest;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface IAppReleaseVersions {
+  _id?: ObjectId;
+  versionName: string;
+  buildNumber: number;
+  releaseNotes: string;
   createdAt: Date;
   updatedAt: Date;
 }


### PR DESCRIPTION
## Summary
- `PATCH /wl/release` now upserts the singleton `appreleaseversions` document in Mongo with the merged release details, in addition to the existing `data/release.json` write.
- Adds `IAppReleaseVersions` type, `Collections.APP_RELEASE_VERSIONS`, and `Mongo.app_release_versions` to the database layer so the controller can write to the collection.

## Why
`tagmango-backend-monorepo`'s `core-api` reads `appreleaseversions.versionName` as `latestAvailableVersionName` in `getAppReleaseVersions` (`apps/core-api/src/api-modules/creator-app-info/creator-app-info.service.ts:35-75`). Today the wl-api PATCH endpoint only updates the local file consumed by the redeployment worker — the DB record never advances, so consumers of `latestAvailableVersionName` see stale data. With this change both stores stay in lockstep on every release.

## Behavior notes
- The upsert sets `versionName`, `buildNumber`, `releaseNotes`, and `updatedAt` from the merged object (file state + PATCH body), and sets `createdAt` on first insert. Matches the mongoose schema in the monorepo (`libs/schemas/src/models/appzap/appReleaseVersions.ts`).
- If the upsert fails the request returns 500 — caller knows the two stores are out of sync and can retry.

## Test plan
- [ ] After deploy, call `PATCH /wl/release` with `{versionName, buildNumber, releaseNotes}` and verify both `data/release.json` and the `appreleaseversions` document update.
- [ ] Hit `core-api`'s `getAppReleaseVersions` and confirm `latestAvailableVersionName` reflects the new value.
- [ ] Force a Mongo failure (drop the collection or break perms) and confirm the endpoint returns 500 without writing the file (or accept current behavior: file write happens first, then DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)