### PR TITLE
refactor(TMG-791): flip deployment request against latestAvailableVersionName

### DIFF
--- a/src/schedules/index.ts
+++ b/src/schedules/index.ts
@@ -25,6 +25,15 @@ const { readFile, writeFile } = fs.promises;
 Mongo.connect().then(() => {
   cron.schedule(UPDATE_IOS_REVIEW_STATUS_CRON, async () => {
     console.log("Running update-ios-review-status schedule");
+
+    const releaseDoc = await Mongo.app_release_versions.findOne({});
+    const latestAvailableVersionName = releaseDoc?.versionName;
+    if (!latestAvailableVersionName) {
+      console.log(
+        "No appreleaseversions document found, deployment requests will not auto-complete this run",
+      );
+    }
+
     const allMetadatas = await Mongo.metadata
       .find({
         $and: [
@@ -112,33 +121,17 @@ Mongo.connect().then(() => {
           );
           count++;
 
-          const deployedVersion =
-            metadata.iosDeploymentDetails?.lastDeploymentDetails?.versionName;
-          const previousAppStoreVersion =
-            metadata.iosDeploymentDetails?.appStore?.versionName;
-          const previousAppStoreStatus =
-            metadata.iosDeploymentDetails?.appStore?.status;
+          // Only flip when the live App Store version matches the latest
+          // release AppZap is pushing to all hosts. Versions in review or
+          // otherwise non-live are left alone.
           const isLive =
             appVersionState === "READY_FOR_SALE" ||
             appVersionState === "READY_FOR_DISTRIBUTION";
-          const wasPreviouslyLive =
-            previousAppStoreStatus === "READY_FOR_SALE" ||
-            previousAppStoreStatus === "READY_FOR_DISTRIBUTION";
-          // Only flip when THIS run observed a transition on the store side
-          // (either a new version or the existing version going from
-          // non-live to live), so a stale match (e.g. request created against
-          // an already-in-sync state or a same-version redeploy) doesn't
-          // auto-complete.
-          const observedTransition =
-            (!!previousAppStoreVersion &&
-              previousAppStoreVersion !== appVersion) ||
-            (!!previousAppStoreStatus && !wasPreviouslyLive && isLive);
 
           if (
-            deployedVersion &&
-            appVersion === deployedVersion &&
-            isLive &&
-            observedTransition
+            latestAvailableVersionName &&
+            appVersion === latestAvailableVersionName &&
+            isLive
           ) {
             const flipResult = await Mongo.deployment_requests.updateOne(
               { host: metadata.host, "ios.status": "processing" },
@@ -390,9 +383,17 @@ Mongo.connect().then(() => {
       return new Promise((resolve) => setTimeout(resolve, delay));
     };
 
-    // Find metadata with an android bundleId where the Play Store version is
-    // either unknown or out-of-date relative to the last AppZap-deployed version
-    // (so we re-scrape after a redeployment until the store catches up).
+    const releaseDoc = await Mongo.app_release_versions.findOne({});
+    const latestAvailableVersionName = releaseDoc?.versionName;
+    if (!latestAvailableVersionName) {
+      console.log(
+        "No appreleaseversions document found, deployment requests will not auto-complete this run",
+      );
+    }
+
+    // Re-scrape hosts whose Play Store version hasn't yet caught up to the
+    // global AppZap target. When the target is unknown, fall back to scraping
+    // hosts that have never been scraped.
     const allMetadatas = await Mongo.metadata
       .find({
         $and: [
@@ -406,28 +407,26 @@ Mongo.connect().then(() => {
               $ne: "",
             },
           },
-          {
-            $or: [
-              {
+          latestAvailableVersionName
+            ? {
                 "androidDeploymentDetails.playStore.versionName": {
-                  $exists: false,
+                  $ne: latestAvailableVersionName,
                 },
+              }
+            : {
+                $or: [
+                  {
+                    "androidDeploymentDetails.playStore.versionName": {
+                      $exists: false,
+                    },
+                  },
+                  {
+                    "androidDeploymentDetails.playStore.versionName": {
+                      $eq: "",
+                    },
+                  },
+                ],
               },
-              {
-                "androidDeploymentDetails.playStore.versionName": {
-                  $eq: "",
-                },
-              },
-              {
-                $expr: {
-                  $ne: [
-                    "$androidDeploymentDetails.lastDeploymentDetails.versionName",
-                    "$androidDeploymentDetails.playStore.versionName",
-                  ],
-                },
-              },
-            ],
-          },
         ],
       })
       .toArray();
@@ -592,22 +591,11 @@ Mongo.connect().then(() => {
               );
               count++;
 
-              const deployedVersion =
-                metadata.androidDeploymentDetails?.lastDeploymentDetails
-                  ?.versionName;
-              const previousPlayStoreVersion =
-                metadata.androidDeploymentDetails?.playStore?.versionName;
-              // Only flip when THIS run observed the store version change, so a
-              // stale match (e.g. request created against an already-in-sync
-              // state or a same-version redeploy) doesn't auto-complete.
-              const observedStoreVersionChange =
-                !!previousPlayStoreVersion &&
-                previousPlayStoreVersion !== version;
-
+              // Only flip when the scraped Play Store version matches the
+              // latest release AppZap is pushing to all hosts.
               if (
-                deployedVersion &&
-                version === deployedVersion &&
-                observedStoreVersionChange
+                latestAvailableVersionName &&
+                version === latestAvailableVersionName
               ) {
                 const flipResult = await Mongo.deployment_requests.updateOne(
                   { host: metadata.host, "android.status": "processing" },


### PR DESCRIPTION
Re-opened from #33 after #32 merged (the original PR was auto-closed when its base branch was deleted).

## Summary
- Replaces the prior transition-detection logic (per-host version drift + iOS state transitions) with a direct comparison against `appreleaseversions.versionName` — the global AppZap release target now synced from `PATCH /wl/release` in #32.
- iOS cron: flips `processing` -> `success` when ASC's `versionString === latestAvailableVersionName` and Apple's state is `READY_FOR_SALE` / `READY_FOR_DISTRIBUTION`.
- Android cron: flips `processing` -> `success` when the scraped Play Store version equals `latestAvailableVersionName`. Scrape filter tightened to only re-scrape hosts whose `playStore.versionName !== latestAvailableVersionName`.
- Net: -59 / +47 lines; the cron is meaningfully simpler.

## Why
Every AppZap redeploy reads its target version from the singleton release record (file today, DB after #32). A deployment request is genuinely complete when the live store version matches that target. Comparing directly against the target removes the previous workarounds:
- No more "did this cron run observe a transition" check.
- No more iOS state-history tracking.
- Relies on the upstream invariant that a deployment request is only created when the host's store version is not yet at `latestAvailableVersionName`, so the cron can treat "store version equals target" as a real completion signal without further guards.

## Test plan
- [ ] Verify `appreleaseversions.versionName` updates on `PATCH /wl/release` (covered by #32).
- [ ] Trigger a redeploy with a new target; observe iOS/Android crons flip `processing` -> `success` once the live store version equals the new target.
- [ ] Confirm Android scrape no longer hits hosts already at the target version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)